### PR TITLE
Configs from env vars

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,0 @@
-{
-  "s3": {
-    "domainName": "",
-    "region": ""
-  }
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import type * as lambda from 'aws-lambda';
 import { LambdaLog, LogMessage } from 'lambda-log';
-import * as config from './config.json';
 import { cfResponseToapigwyResponse } from './lib/cfToApigwy';
 import { apigwyEventTocfRequestEvent } from './lib/apigwyToCF';
 import { binaryMimeTypes, fetchFromS3 } from './lib/s3fetch';
+import { Config } from './lib/config';
 
 export type routerState = {
   event: lambda.APIGatewayProxyEventV2;
@@ -13,6 +13,7 @@ export type routerState = {
 const localTesting = process.env.DEBUG ? true : false;
 
 let log: LambdaLog;
+const config = Config.instance;
 
 export async function handler(
   event: lambda.APIGatewayProxyEventV2,
@@ -85,7 +86,7 @@ export async function handler(
 
       // Fall through to S3
       const cfEvent = apigwyEventTocfRequestEvent('origin-request', event, config);
-      const s3Response = await fetchFromS3(cfEvent.Records[0].cf.request);
+      const s3Response = await fetchFromS3(cfEvent.Records[0].cf.request, config);
 
       decodeResponse(s3Response);
 
@@ -168,7 +169,7 @@ export async function handler(
       const cfRequestForOrigin = (cfRequestResult as unknown) as lambda.CloudFrontRequest;
 
       // Fall through to S3
-      const s3Response = await fetchFromS3(cfRequestForOrigin);
+      const s3Response = await fetchFromS3(cfRequestForOrigin, config);
 
       log.debug('got response from s3', { s3Response });
 

--- a/src/lib/apigwyToCF.ts
+++ b/src/lib/apigwyToCF.ts
@@ -1,9 +1,12 @@
 import type * as lambda from 'aws-lambda';
+import { IConfig } from './config';
+
+let s3BucketName: string;
 
 export function apigwyEventTocfRequestEvent(
   cfEventType: string,
   event: lambda.APIGatewayProxyEventV2,
-  config: any,
+  config: IConfig,
 ): lambda.CloudFrontRequestEvent {
   const cfEvent = {
     Records: [{ cf: { config: { eventType: cfEventType }, request: { headers: {}, origin: {} } } }],
@@ -40,14 +43,21 @@ export function apigwyEventTocfRequestEvent(
     };
   }
 
+  // The bucket name doesn't change, get it once
+  if (s3BucketName !== undefined) {
+    s3BucketName = process.env.S3BUCKETNAME as string;
+  }
+
   // Fake the Origin object
   if (cfRequest.origin !== undefined) {
     cfRequest.origin.s3 = {
       customHeaders: {
         cat: [{ key: 'cat', value: 'dog' }],
       },
-      domainName: config.s3.domainName,
-      region: config.s3.region,
+      domainName: config.s3BucketName,
+      // We use AWS_REGION env var instead
+      region: 'dummy',
+      // region: config.s3.region,
       path: '',
       // CF uses OAI to access S3 from Lambda @ Edge
       // But from Lambda we can just have IAM privs to get/put

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,50 @@
+export interface IConfig {
+  region: string;
+  s3BucketName: string;
+  s3DomainName: string;
+}
+
+export class Config implements IConfig {
+  private static _instance: Config;
+  public static get instance(): IConfig {
+    if (Config._instance === undefined) {
+      Config._instance = new Config();
+    }
+    return Config._instance;
+  }
+
+  private constructor() {
+    this._region = process.env.AWS_REGION || 'MicroApps';
+    this._s3BucketName = process.env.S3BUCKETNAME || 'MicroApps';
+    this._s3DomainName = '';
+    const regionInfix = this._region === 'us-east-1' ? '' : `${this._region}.`;
+    this._s3DomainName = `${this._s3BucketName}.s3.${regionInfix}amazonaws.com`;
+  }
+
+  public static get envLevel(): 'dev' | 'qa' | 'prod' | 'local' {
+    const nodeEnv = process.env.NODE_ENV || 'dev';
+    if (nodeEnv.startsWith('prod')) {
+      return 'prod';
+    } else if ((nodeEnv as string) === 'qa') {
+      return 'qa';
+    } else if ((nodeEnv as string) === 'local') {
+      return 'local';
+    }
+    return 'dev';
+  }
+
+  private _region: string;
+  public get region(): string {
+    return this._region;
+  }
+
+  private _s3BucketName: string;
+  public get s3BucketName(): string {
+    return this._s3BucketName;
+  }
+
+  private _s3DomainName: string;
+  public get s3DomainName(): string {
+    return this._s3DomainName;
+  }
+}


### PR DESCRIPTION
- Remove usage of `config.json` in consuming app
- Use env vars for config instead